### PR TITLE
Implement GetAddresses for TxStakeCompound type

### DIFF
--- a/types/tx.go
+++ b/types/tx.go
@@ -279,7 +279,7 @@ func (t *Tx) GetAddresses() []string {
 		return append(addresses, t.From, t.To)
 	case TxSwap:
 		return append(addresses, t.From, t.To)
-	case TxStakeDelegate, TxStakeRedelegate, TxStakeUndelegate, TxStakeClaimRewards:
+	case TxStakeDelegate, TxStakeRedelegate, TxStakeUndelegate, TxStakeClaimRewards, TxStakeCompound:
 		return append(addresses, t.From)
 	default:
 		return addresses

--- a/types/tx_test.go
+++ b/types/tx_test.go
@@ -227,6 +227,16 @@ func TestTx_GetAddresses(t *testing.T) {
 			},
 			expected: []string{"from_utxo", "to_utxo"},
 		},
+		{
+			name: "stake_compound",
+			tx: Tx{
+				Type:     TxStakeCompound,
+				From:     "from",
+				To:       "to",
+				Metadata: &Transfer{},
+			},
+			expected: []string{"from"},
+		},
 	}
 
 	for _, tc := range tests {
@@ -238,6 +248,19 @@ func TestTx_GetAddresses(t *testing.T) {
 		})
 	}
 
+	// make sure all supported types have a test
+	supportedTypesMap := map[TransactionType]struct{}{}
+	for _, supportedType := range SupportedTypes {
+		supportedTypesMap[supportedType] = struct{}{}
+	}
+
+	testedTypesMap := map[TransactionType]struct{}{}
+	for _, tc := range tests {
+		if _, supported := supportedTypesMap[tc.tx.Type]; supported {
+			testedTypesMap[tc.tx.Type] = struct{}{}
+		}
+	}
+	assert.Equal(t, len(supportedTypesMap), len(testedTypesMap))
 }
 
 func TestTx_GetDirection(t *testing.T) {


### PR DESCRIPTION
I'm working on https://github.com/trustwallet/atlas/issues/610 and have an open PR for that issue https://github.com/trustwallet/atlas/pull/756

While testing that PR, the consumer doesn't process the transactions for `TxStakeCompound`. After debugging, the cause is that `GetAddresses` doesn't return any addresses for `TxStakeCompound`, causing the consumer to think this transaction is not a transaction for subscribed wallet addresses

This PR fixes that by implementing the `GetAddress` function for `TxStakeCompound`. Additionally, it adds a guard in the unit test to make sure every transaction types in `SupportedTypes` slice have at least 1 test