### PR TITLE
Add algorand explorer

### DIFF
--- a/coin/models.go
+++ b/coin/models.go
@@ -124,6 +124,8 @@ func GetCoinExploreURL(c Coin, tokenID, tokenType string) (string, error) {
 		return fmt.Sprintf("https://explorer.kcc.io/token/%s", tokenID), nil
 	case AURORA:
 		return fmt.Sprintf("https://aurorascan.dev/address/%s", tokenID), nil
+	case ALGORAND:
+		return fmt.Sprintf("https://algoexplorer.io/asset/%s", tokenID), nil
 	}
 
 	return "", errors.New("no explorer for coin: " + c.Handle)

--- a/coin/models_test.go
+++ b/coin/models_test.go
@@ -141,6 +141,16 @@ func TestGetCoinExploreURL(t *testing.T) {
 			want:    "https://explorer.kcc.io/token/0x2cA48b4eeA5A731c2B54e7C3944DBDB87c0CFB6F",
 			wantErr: false,
 		},
+		{
+			name: "Test Algorand",
+			args: args{
+				addr:      "test",
+				tokenType: "ALGORAND",
+				chain:     Algorand(),
+			},
+			want:    "https://algoexplorer.io/asset/test",
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
There is a failed CI for PR in assets repo: https://github.com/trustwallet/assets/pull/20961

It fails because go-primitives is missing explorer URL for the token