### PR TITLE
fix avalanche explorer url

### DIFF
--- a/coin/models.go
+++ b/coin/models.go
@@ -73,7 +73,7 @@ func GetCoinExploreURL(c Coin, tokenID, tokenType string) (string, error) {
 	case OPTIMISM:
 		return fmt.Sprintf("https://optimistic.etherscan.io/token/%s", tokenID), nil
 	case AVALANCHEC:
-		return fmt.Sprintf("https://snowtrace.io/address/%s", tokenID), nil
+		return fmt.Sprintf("https://snowtrace.io/token/%s", tokenID), nil
 	case ARBITRUM:
 		return fmt.Sprintf("https://arbiscan.io/token/%s", tokenID), nil
 	case FANTOM:


### PR DESCRIPTION
this pr is related to [this issue](https://github.com/trustwallet/assets-manager/issues/82)
we do support snowtrace url but with a wrong suffix. (see changes)

currently there are [61 assets](https://github.com/trustwallet/assets/search?p=5&q=https%3A%2F%2Fsnowtrace.io%2Faddress) which refer to the old explorer url. 

GetCoinExploreURL func has several references across services, after some research, we will have no issue with the old ones, as the fix (assets repo gh action) will kick in and fix the url. (to be verified)