### PR TITLE
Fix HexNumber MarshalJSON

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -10,7 +10,7 @@ import (
 type HexNumber big.Int
 
 func (i HexNumber) MarshalJSON() ([]byte, error) {
-	hexNumber := fmt.Sprintf("\"0x%x\"", (*big.Int)(&i).Uint64())
+	hexNumber := fmt.Sprintf("\"0x%x\"", (*big.Int)(&i))
 
 	return []byte(hexNumber), nil
 }

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -1,0 +1,42 @@
+package types
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHex_UnmarshalAndMarshalJSON(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  []byte
+		result string
+	}{
+		{
+			input:  []byte(`{"value":"0x850a9af493d065b6c"}`),
+			result: "153386322112866048876",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			type req struct {
+				Value *HexNumber `json:"value"`
+			}
+
+			var v req
+
+			err := json.Unmarshal(tc.input, &v)
+			assert.NoError(t, err)
+
+			output := (*big.Int)(v.Value)
+			assert.Equal(t, tc.result, output.String())
+
+			bytes, err := json.Marshal(v)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.input, bytes)
+		})
+	}
+}

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -10,13 +10,34 @@ import (
 
 func TestHex_UnmarshalAndMarshalJSON(t *testing.T) {
 	tests := []struct {
-		name   string
-		input  []byte
-		result string
+		name    string
+		input   []byte
+		result  string
+		isError bool
 	}{
 		{
-			input:  []byte(`{"value":"0x850a9af493d065b6c"}`),
-			result: "153386322112866048876",
+			name:    "value greater than 2^64 -1",
+			input:   []byte(`{"value":"0x850a9af493d065b6c"}`),
+			result:  "153386322112866048876",
+			isError: false,
+		},
+		{
+			name:    "value less than 2^64 -1",
+			input:   []byte(`{"value":"0x746a528800"}`),
+			result:  "500000000000",
+			isError: false,
+		},
+		{
+			name:    "error case: not hex (string)",
+			input:   []byte(`{"value":"error_value"}`),
+			result:  "",
+			isError: true,
+		},
+		{
+			name:    "error case: not hex (octal)",
+			input:   []byte(`{"value":"20502515364447501455554"}`),
+			result:  "",
+			isError: true,
 		},
 	}
 
@@ -29,6 +50,9 @@ func TestHex_UnmarshalAndMarshalJSON(t *testing.T) {
 			var v req
 
 			err := json.Unmarshal(tc.input, &v)
+			if tc.isError {
+				return
+			}
 			assert.NoError(t, err)
 
 			output := (*big.Int)(v.Value)


### PR DESCRIPTION
Found a bug in `HexNumber.MarshalJSON` function:

`HexNumber` is often used in Ethereum-like chains for fetching and unmarshalling block/tx data.

Example:
If we try to parse this transaction https://scan.meter.io/tx/0x9bc03d4c7a9dab5666a085d9125bfe2cf2de75df05121c116e7a0b622d6a45aa, we will parse it correctly on the Txhub.Fetcher side because it will use Hex.UnmarshalJSON while unmarshalling the block.
But before sending this fetched block to the queue, it has to marshal it again, so it will use Hex.MarshalJSON which will lead to a different result.

Just tried to do Unmarshal and Marshal on this tx and here is result:

After Unmarshalling
```
{
    "hash": "0x0209ff9fabcbbd6a038a0fa99d601bad3ab9d7133316928f9ea3bdb5114d5e58",
    "number": "0x209ff9f",
    "timestamp": "0x63fdd272",
    "parentHash": "0x0209ff9e3bfd794e5f5f6f7d65235caf478e154885add68551ce857954714bce",
    "transactions": [
        {
            "hash": "0x9bc03d4c7a9dab5666a085d9125bfe2cf2de75df05121c116e7a0b622d6a45aa",
            "nonce": "0xe658958f768727e0",
            "blockNumber": "0x209ff9f",
            "transactionIndex": "0x0",
            "from": "0xefad8808aeed83897d17a8fe8b41e64b9646a151",
            "to": "0x68a06993e5c5a2b7fc88260285e1a03df2e10a1f",
            "value": "0x850a9af493d065b6c",
            "gas": "0x5208",
            "gasPrice": "0x746a528800",
            "input": "0x",
            "type": "0x0",
            "maxPriorityFeePerGas": "0x0"
        }
    ],
    "baseFeePerGas": "0x746a528800"
}
```

After Marshalling
```
{
    "hash": "0x0209ff9fabcbbd6a038a0fa99d601bad3ab9d7133316928f9ea3bdb5114d5e58",
    "number": "0x209ff9f",
    "timestamp": "0x63fdd272",
    "parentHash": "0x0209ff9e3bfd794e5f5f6f7d65235caf478e154885add68551ce857954714bce",
    "transactions": [
        {
            "hash": "0x9bc03d4c7a9dab5666a085d9125bfe2cf2de75df05121c116e7a0b622d6a45aa",
            "nonce": "0xe658958f768727e0",
            "blockNumber": "0x209ff9f",
            "transactionIndex": "0x0",
            "from": "0xefad8808aeed83897d17a8fe8b41e64b9646a151",
            "to": "0x68a06993e5c5a2b7fc88260285e1a03df2e10a1f",
            "value": "0x50a9af493d065b6c",
            "gas": "0x5208",
            "gasPrice": "0x746a528800",
            "input": "0x",
            "type": "0x0",
            "maxPriorityFeePerGas": "0x0"
        }
    ],
    "baseFeePerGas": "0x746a528800"
}
```

Look at the `"value"` field.
Because of that, some of Ethereum-like chains transactions are affected with a wrong transaction amount.
