### PR TITLE
support for aptos fungible assets

### DIFF
--- a/coin/models.go
+++ b/coin/models.go
@@ -113,7 +113,12 @@ func GetCoinExploreURL(c Coin, tokenID, tokenType string) (string, error) {
 	case OKC:
 		return fmt.Sprintf("https://www.oklink.com/en/okc/address/%s", tokenID), nil
 	case APTOS:
-		return "https://explorer.aptoslabs.com/", nil
+		switch tokenType {
+		case "APTOSFA":
+			return fmt.Sprintf("https://explorer.aptoslabs.com/fungible_asset/%s?network=mainnet", tokenID), nil
+		default:
+			return fmt.Sprintf("https://explorer.aptoslabs.com/coin/%s?network=mainnet", tokenID), nil
+		}
 	case MOONBEAM:
 		return fmt.Sprintf("https://moonscan.io/token/%s", tokenID), nil
 	case KLAYTN:

--- a/coin/models_test.go
+++ b/coin/models_test.go
@@ -427,6 +427,26 @@ func TestGetCoinExploreURL(t *testing.T) {
 			want:    "https://explorer.zklink.io/address/0xF573fA04A73d5AC442F3DEa8741317fEaA3cDeab",
 			wantErr: false,
 		},
+		{
+			name: "Test Aptos (legacy)",
+			args: args{
+				addr:      "0xacd014e8bdf395fa8497b6d585b164547a9d45269377bdf67c96c541b7fec9ed::coin::T",
+				tokenType: "APTOS",
+				chain:     Aptos(),
+			},
+			want:    "https://explorer.aptoslabs.com/coin/0xacd014e8bdf395fa8497b6d585b164547a9d45269377bdf67c96c541b7fec9ed::coin::T?network=mainnet",
+			wantErr: false,
+		},
+		{
+			name: "Test Aptos (fungible asset)",
+			args: args{
+				addr:      "0x357b0b74bc833e95a115ad22604854d6b0fca151cecd94111770e5d6ffc9dc2b",
+				tokenType: "APTOSFA",
+				chain:     Aptos(),
+			},
+			want:    "https://explorer.aptoslabs.com/fungible_asset/0x357b0b74bc833e95a115ad22604854d6b0fca151cecd94111770e5d6ffc9dc2b?network=mainnet",
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/types/chain.go
+++ b/types/chain.go
@@ -93,7 +93,7 @@ func GetChainFromAssetType(assetType string) (coin.Coin, error) {
 		return coin.Evmos(), nil
 	case KIP20:
 		return coin.Okc(), nil
-	case APTOS:
+	case APTOS, APTOSFA:
 		return coin.Aptos(), nil
 	case MOONBEAM:
 		return coin.Moonbeam(), nil

--- a/types/chain_test.go
+++ b/types/chain_test.go
@@ -90,6 +90,22 @@ func TestGetChainFromAssetType(t *testing.T) {
 			want:    coin.Cfxevm(),
 			wantErr: false,
 		},
+		{
+			name: "Test APTOS (legacy)",
+			args: args{
+				type_: "APTOS",
+			},
+			want:    coin.Aptos(),
+			wantErr: false,
+		},
+		{
+			name: "Test APTOSFA (fungible asset)",
+			args: args{
+				type_: "APTOSFA",
+			},
+			want:    coin.Aptos(),
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/types/token.go
+++ b/types/token.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/trustwallet/go-primitives/asset"
 	"github.com/trustwallet/go-primitives/coin"
@@ -88,6 +89,7 @@ const (
 	EVMOS_ERC20     TokenType = "EVMOS_ERC20"
 	KIP20           TokenType = "KIP20"
 	APTOS           TokenType = "APTOS"
+	APTOSFA         TokenType = "APTOSFA"
 	MOONBEAM        TokenType = "MOONBEAM"
 	KLAYTN          TokenType = "KAIA"
 	METIS           TokenType = "METIS"
@@ -146,6 +148,7 @@ const (
 	TokenVersionV18       TokenVersion = 18
 	TokenVersionV19       TokenVersion = 19
 	TokenVersionV20       TokenVersion = 20
+	TokenVersionV21       TokenVersion = 21
 	TokenVersionUndefined TokenVersion = -1
 )
 
@@ -211,6 +214,7 @@ func GetTokenTypes() []TokenType {
 		EVMOS_ERC20,
 		KIP20,
 		APTOS,
+		APTOSFA,
 		MOONBEAM,
 		KLAYTN,
 		METIS,
@@ -319,7 +323,11 @@ func GetTokenType(c uint, tokenID string) (string, bool) {
 	case coin.OKC:
 		return string(KIP20), true
 	case coin.APTOS:
-		return string(APTOS), true
+		// TODO: improve this
+		if strings.Contains(tokenID, "::") {
+			return string(APTOS), true
+		}
+		return string(APTOSFA), true
 	case coin.TON:
 		return string(JETTON), true
 	case coin.SUI:
@@ -428,6 +436,8 @@ func GetTokenVersion(tokenType string) (TokenVersion, error) {
 	case ERC721, ERC1155, EOS, NEP5, VET, ONTOLOGY, THETA, TOMO, POA, OASIS, ALGORAND, METER, EVMOS_ERC20,
 		KIP20, STRIDE, NEUTRON, FA2, CARDANO, NATIVEEVMOS, CRYPTOORG, COSMOS, OSMOSIS, STARGAZE:
 		return TokenVersionUndefined, nil
+	case APTOSFA:
+		return TokenVersionV21, nil
 	default:
 		// This should not happen, as it is guarded by TestGetTokenVersionImplementEverySupportedTokenTypes
 		return TokenVersionUndefined, fmt.Errorf("tokenType %s: %w", parsedTokenType, errTokenVersionNotImplemented)

--- a/types/token_test.go
+++ b/types/token_test.go
@@ -306,8 +306,14 @@ func TestGetTokenType(t *testing.T) {
 		},
 		{
 			name:     "Aptos",
-			args:     args{coin.APTOS, ""},
+			args:     args{coin.APTOS, "0xf22bede237a07e121b56d91a491eb7bcdfd1f5907926a9e58338f964a01b17fa::asset::USDT"},
 			want:     string(APTOS),
+			wantBool: true,
+		},
+		{
+			name:     "Aptos",
+			args:     args{coin.APTOS, "0x357b0b74bc833e95a115ad22604854d6b0fca151cecd94111770e5d6ffc9dc2b"},
+			want:     string(APTOSFA),
 			wantBool: true,
 		},
 		{


### PR DESCRIPTION
Context:  needed to differentiate between legacy and new aptos fungible assets.
